### PR TITLE
启动的时候，因为日志的依赖启动不了

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@
 - 注册中心 test-skywalking-eureka
 - 服务端 test-skywalking-producer
 - 服务调用方 test-skywalking-customer
-- 分别启动 test-skywalking-eureka、test-skywalking-producer、test-skywalking-customer
+- 启动 test-skywalking-eureka
+- 启动 test-skywalking-producer(添加jvm参数-javaagent:/Users/jsohpillyu/Public/developware/apache-skywalking-apm-bin/agent/skywalking-agent.jar -DSW_AGENT_NAME=producer -Dskywalking.collector.servers=localhost:10800)
+- 启动 test-skywalking-customer(-javaagent:/Users/jsohpillyu/Public/developware/apache-skywalking-apm-bin/agent/skywalking-agent.jar -DSW_AGENT_NAME=consumer -Dskywalking.collector.servers=localhost:10800)
 
 ####SkyWalking效果展示
 

--- a/test-skywalking-customer/pom.xml
+++ b/test-skywalking-customer/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.skywalking</groupId>
-            <artifactId>apm-toolkit-log4j-1.x</artifactId>
+            <artifactId>apm-toolkit-logback-1.x</artifactId>
             <version>6.1.0</version>
         </dependency>
         <dependency>

--- a/test-skywalking-customer/src/main/resources/logback-spring.xml
+++ b/test-skywalking-customer/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
             <maxFileSize>500MB</maxFileSize>
             <maxHistory>100</maxHistory>
         </rollingPolicy>
-        <encoder>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.TraceIdPatternLogbackLayout">
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%tid] [%thread] %-5level %logger{36} -%msg%n</Pattern>
             </layout>

--- a/test-skywalking-producer/pom.xml
+++ b/test-skywalking-producer/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.skywalking</groupId>
-            <artifactId>apm-toolkit-log4j-1.x</artifactId>
+            <artifactId>apm-toolkit-logback-1.x</artifactId>
             <version>6.1.0</version>
         </dependency>
         <dependency>

--- a/test-skywalking-producer/src/main/resources/logback-spring.xml
+++ b/test-skywalking-producer/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
             <maxFileSize>500MB</maxFileSize>
             <maxHistory>100</maxHistory>
         </rollingPolicy>
-        <encoder>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="org.apache.skywalking.apm.toolkit.log.logback.v1.x.TraceIdPatternLogbackLayout">
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%tid] [%thread] %-5level %logger{36} -%msg%n</Pattern>
             </layout>


### PR DESCRIPTION
logback-spring.xml里面配置的是logback相关的类，但是pom.xml里面依赖的却是log4j相关的包，导致启动的时候报ClassNotFound的错误。

需要把依赖包改成logback相关的包。